### PR TITLE
Python doc-strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,9 @@ target_link_libraries(galfunc galfuncobjects)
 
 # Python shared lib
 add_library(pygalfunc SHARED $<TARGET_OBJECTS:galfuncobjects>)
-set_target_properties(pygalfunc PROPERTIES SUFFIX .so)
-set_target_properties(pygalfunc PROPERTIES PREFIX "")
+set_target_properties(pygalfunc PROPERTIES
+  SUFFIX .so
+  PREFIX "")
 target_link_libraries(pygalfunc galfuncobjects)
 # Copy the python setup file
 add_custom_command(TARGET pygalfunc

--- a/include/galfunc/Functions.h
+++ b/include/galfunc/Functions.h
@@ -584,12 +584,28 @@ typename TVariable<TVal>::PyOutputType py_varEmpty()
 
 namespace python {
 
+/**
+ * @brief Python doc-string of a function.
+ *
+ */
 struct FuncDocString
 {
+  /**
+   * @brief Create a new python doc-string.
+   *
+   * @param desc Description of the function.
+   * @param inputs Names and descriptions of inputs.
+   * @param outputs Names and descriptions of outputs.
+   */
   FuncDocString(const std::string&                                      desc,
                 const std::vector<std::pair<std::string, std::string>>& inputs,
                 const std::vector<std::pair<std::string, std::string>>& outputs);
 
+  /**
+   * @brief Gets the c-string representation of the python doc-string.
+   *
+   * @return char* c-string.
+   */
   const char* c_str() const;
 
 private:
@@ -632,7 +648,7 @@ fs::path getcontextpath();
 // Get the type from an arg-tuple that has description.
 #define _GAL_ARG_TYPE(type, name, desc) GAL_UNBRACED_TYPE(type)
 #define GAL_ARG_TYPE(argTuple) _GAL_ARG_TYPE argTuple
-// Get the const type from an arg-tuple with description.
+// Get the const type from an arg-tuple.
 #define _GAL_ARG_CONST_TYPE(type, name, desc) std::add_const_t<GAL_UNBRACED_TYPE(type)>
 #define GAL_ARG_CONST_TYPE(argTuple) _GAL_ARG_CONST_TYPE argTuple
 // Get the name from an arg-tuple.
@@ -641,33 +657,33 @@ fs::path getcontextpath();
 // Expand types from a list of arg-tuples.
 #define _GAL_EXPAND_TYPE_TUPLE(...) MAP_LIST(GAL_ARG_TYPE, __VA_ARGS__)
 #define GAL_EXPAND_TYPE_TUPLE(types) _GAL_EXPAND_TYPE_TUPLE types
-// Expand const types from a list of arg-tuples with description.
+// Expand const types from a list of arg-tuples.
 #define _GAL_EXPAND_CONST_TYPE_TUPLE(...) MAP_LIST(GAL_ARG_CONST_TYPE, __VA_ARGS__)
 #define GAL_EXPAND_CONST_TYPE_TUPLE(types) _GAL_EXPAND_CONST_TYPE_TUPLE types
 // Get reference type from an arg-tuple.
 #define GAL_EXPAND_IMPL_ARG(argTuple) \
   typename gal::func::ImplFnArgType<GAL_ARG_TYPE(argTuple)>::Type GAL_ARG_NAME(argTuple)
-// Get the const reference type from an arg-tuple with description.
+// Get the const reference type from an arg-tuple.
 #define GAL_EXPAND_IMPL_CONST_ARG(argTuple)                                           \
   typename gal::func::ImplFnArgType<GAL_ARG_CONST_TYPE(argTuple)>::Type GAL_ARG_NAME( \
     argTuple)
-// Expand to a list of references from arg-tuples with description.
+// Expand to a list of references from arg-tuples.
 #define GAL_EXPAND_IMPL_ARGS(...) MAP_LIST(GAL_EXPAND_IMPL_ARG, __VA_ARGS__)
-// Expand to a list of const references from arg-tuples with description.
+// Expand to a list of const references from arg-tuples.
 #define GAL_EXPAND_IMPL_CONST_ARGS(...) MAP_LIST(GAL_EXPAND_IMPL_CONST_ARG, __VA_ARGS__)
 // Get the register type for the python function argument.
 #define GAL_PY_REGISTER_TYPE(typeTuple) \
   const gal::func::ArgRegisterT<GAL_ARG_TYPE(typeTuple)>&
-// Get python register argument from an arg-tuple with description.
+// Get python register argument from an arg-tuple.
 #define GAL_PY_REGISTER_ARG(typeTuple) \
   GAL_PY_REGISTER_TYPE(typeTuple) GAL_ARG_NAME(typeTuple)
-// Get python argument register list from arg-tuples with descriptions.
+// Get python argument register list from arg-tuples.
 #define GAL_EXPAND_PY_REGISTER_ARGS(...) MAP_LIST(GAL_PY_REGISTER_ARG, __VA_ARGS__)
 // Get python argument type list.
 #define GAL_EXPAND_PY_REGISTER_TYPES(...) MAP_LIST(GAL_PY_REGISTER_TYPE, __VA_ARGS__)
 // Name of a function implementation.
 #define GAL_FN_IMPL_NAME(fnName) GAL_CONCAT(fnName, _impl)
-// Get register ids from arg-tuples without descriptions.
+// Get register ids from arg-tuples.
 #define GAL_EXPAND_REG_NAMES(...) MAP_LIST(GAL_ARG_NAME, __VA_ARGS__)
 // Actual declaration of a the static implementation of the function.
 #define GAL_FN_IMPL(fnName, inputs, outputs)                              \

--- a/scripts/test_utilFunctions.py
+++ b/scripts/test_utilFunctions.py
@@ -2,6 +2,7 @@ import pygalfunc as pgf
 import testUtil as tu
 import math
 import random
+import itertools
 
 
 def unaryFloatOpTest(expFn, pgfn, minval=0., maxval=9.):
@@ -259,5 +260,22 @@ def test_dispatch():
         assert tu.equal(fvals, pgf.read(rfvals))
 
 
+def test_combinations():
+    random.seed(42)
+    valrange = (23, 345)
+    rvals = pgf.var_int()
+    rnumc = pgf.var_int()
+    rcombs = pgf.combinations(rvals, rnumc)
+    for _ in range(5):
+        nItems = random.randint(23, 29)
+        numc = random.randint(3, 5)
+        vals = [random.randint(valrange[0], valrange[1]) for _ in range(nItems)]
+        combs = list(itertools.combinations(vals, numc))
+
+        pgf.assign(rvals, vals)
+        pgf.assign(rnumc, numc)
+        assert tu.equal(combs, pgf.read(rcombs))
+
+
 if __name__ == "__main__":
-    test_dispatch()
+    test_combinations()

--- a/src/galfunc/Functions.cpp
+++ b/src/galfunc/Functions.cpp
@@ -56,6 +56,7 @@ void unloadAllFunctions()
 }  // namespace store
 
 namespace python {
+
 fs::path getcontextpath()
 {
   using namespace boost::python;
@@ -82,6 +83,31 @@ fs::path getcontextpath()
   result = filename.stem() / result;
   return result;
 }
+
+FuncDocString::FuncDocString(
+  const std::string&                                      desc,
+  const std::vector<std::pair<std::string, std::string>>& inputs,
+  const std::vector<std::pair<std::string, std::string>>& outputs)
+{
+  mDocString  = desc + "\n";
+  size_t argI = 0;
+  for (const auto& argpair : inputs) {
+    mDocString += argpair.first + ": " + argpair.second;
+  }
+  mDocString +=
+    "\n****"
+    " Return values "
+    "****\n";
+  for (const auto& argpair : outputs) {
+    mDocString += argpair.first + ": " + argpair.second;
+  }
+}
+
+const char* FuncDocString::c_str() const
+{
+  return mDocString.c_str();
+}
+
 }  // namespace python
 
 // Forward declare the binding functions.

--- a/src/galfunc/UtilFunctions.cpp
+++ b/src/galfunc/UtilFunctions.cpp
@@ -228,6 +228,24 @@ GAL_FUNC_TEMPLATE(((typename, T)),
   result = std::to_string(src);
 }
 
+GAL_FUNC_TEMPLATE(
+  ((typename, T)),
+  combinations,
+  "Creates all possible combinations of elements from the given list",
+  (((data::ReadView<T, 1>), items, "Items to create the combinations from."),
+   (int32_t, nc, "Number of items in each combination")),
+  (((data::WriteView<T, 2>), combs, "Resulting combinations")))
+{
+  size_t n = items.size();
+  size_t k = size_t(nc);
+  combs.reserve(k * utils::numCombinations(items.size(), size_t(k)));
+  std::vector<T> temp(k);
+  utils::combinations(k, items.begin(), items.end(), temp.begin(), [&]() {
+    auto child = combs.child();
+    std::move(temp.begin(), temp.end(), std::back_inserter(child));
+  });
+}
+
 template<typename T>
 struct bindAllTypes
 {
@@ -238,6 +256,7 @@ struct bindAllTypes
     GAL_FN_BIND_TEMPLATE(subList, T);
     GAL_FN_BIND_TEMPLATE(listLength, T);
     GAL_FN_BIND_TEMPLATE(dispatch, T);
+    GAL_FN_BIND_TEMPLATE(combinations, T);
   }
 };
 


### PR DESCRIPTION
Adds doc-strings to all the python bindings.
closes #14 